### PR TITLE
fix: Update hint for calculating median in Step 22

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/635090f47eb6d9563a6fed05.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-advanced-array-methods-by-building-a-statistics-calculator/635090f47eb6d9563a6fed05.md
@@ -31,10 +31,10 @@ Your `median` variable should use a ternary operator to check if the `array.leng
 assert.match(getMedian.toString(), /median\s*=\s*array\.length\s*%\s*2\s*===\s*0\s*\?/);
 ```
 
-If the `array.length` is even, your `median` variable should use the `getMean` function to calculate the mean of the two middle numbers. Your first argument should be the value of `sorted` at `array.length / 2`, and the second at `array.length / 2 - 1`.
+If the `array.length` is even, pass an array with the two middle numbers from the sorted array to the `getMean` function. This first item in the array argument should be the value at index `array.length / 2 - 1` from `sorted`, and the second should use the value at index `array.length / 2` from `sorted`.
 
 ```js
-assert.match(getMedian.toString(), /median\s*=\s*array\.length\s*%\s*2\s*===\s*0\s*\?\s*getMean\(\s*\[sorted\[array\.length\s*\/\s*2\]\s*,\s*sorted\[\s*array\.length\s*\/\s*2\s*-\s*1\]\]\)\s*\:/);
+assert.match(getMedian.toString(), /median\s*=\s*array\.length\s*%\s*2\s*===\s*0\s*\?\s*getMean\(\s*\[sorted\[array\.length\s*\/\s*2\s*-\s*1\]\s*,\s*sorted\[array\.length\s*\/\s*2\]\]\)\s*\:/);
 ```
 
 If the `array.length` is odd, your `median` variable should assign the middle number to the `median` variable. The middle number is the value of `sorted` at `Math.floor(array.length / 2)`.


### PR DESCRIPTION
Correct the instructions in the third hint of Step 22 to clarify the usage of the getMean function when the array length is even. The updated hint now accurately describes passing an array with the two middle numbers from the sorted array to getMean.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #52955

<!-- Feel free to add any additional description of changes below this line -->
